### PR TITLE
Add keyword filtering to code style rules

### DIFF
--- a/pkg/core/resource_repo_mock.go
+++ b/pkg/core/resource_repo_mock.go
@@ -23,9 +23,9 @@ func (_m *MockResourceRepo) EXPECT() *MockResourceRepo_Expecter {
 	return &MockResourceRepo_Expecter{mock: &_m.Mock}
 }
 
-// GetCodeStyle provides a mock function with given fields: ctx, categories
-func (_m *MockResourceRepo) GetCodeStyle(ctx context.Context, categories []string) ([]Rule, error) {
-	ret := _m.Called(ctx, categories)
+// GetCodeStyle provides a mock function with given fields: ctx, categories, keywords
+func (_m *MockResourceRepo) GetCodeStyle(ctx context.Context, categories []string, keywords []string) ([]Rule, error) {
+	ret := _m.Called(ctx, categories, keywords)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetCodeStyle")
@@ -33,19 +33,19 @@ func (_m *MockResourceRepo) GetCodeStyle(ctx context.Context, categories []strin
 
 	var r0 []Rule
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, []string) ([]Rule, error)); ok {
-		return rf(ctx, categories)
+	if rf, ok := ret.Get(0).(func(context.Context, []string, []string) ([]Rule, error)); ok {
+		return rf(ctx, categories, keywords)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, []string) []Rule); ok {
-		r0 = rf(ctx, categories)
+	if rf, ok := ret.Get(0).(func(context.Context, []string, []string) []Rule); ok {
+		r0 = rf(ctx, categories, keywords)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]Rule)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, []string) error); ok {
-		r1 = rf(ctx, categories)
+	if rf, ok := ret.Get(1).(func(context.Context, []string, []string) error); ok {
+		r1 = rf(ctx, categories, keywords)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -61,13 +61,14 @@ type MockResourceRepo_GetCodeStyle_Call struct {
 // GetCodeStyle is a helper method to define mock.On call
 //   - ctx context.Context
 //   - categories []string
-func (_e *MockResourceRepo_Expecter) GetCodeStyle(ctx interface{}, categories interface{}) *MockResourceRepo_GetCodeStyle_Call {
-	return &MockResourceRepo_GetCodeStyle_Call{Call: _e.mock.On("GetCodeStyle", ctx, categories)}
+//   - keywords []string
+func (_e *MockResourceRepo_Expecter) GetCodeStyle(ctx interface{}, categories interface{}, keywords interface{}) *MockResourceRepo_GetCodeStyle_Call {
+	return &MockResourceRepo_GetCodeStyle_Call{Call: _e.mock.On("GetCodeStyle", ctx, categories, keywords)}
 }
 
-func (_c *MockResourceRepo_GetCodeStyle_Call) Run(run func(ctx context.Context, categories []string)) *MockResourceRepo_GetCodeStyle_Call {
+func (_c *MockResourceRepo_GetCodeStyle_Call) Run(run func(ctx context.Context, categories []string, keywords []string)) *MockResourceRepo_GetCodeStyle_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].([]string))
+		run(args[0].(context.Context), args[1].([]string), args[2].([]string))
 	})
 	return _c
 }
@@ -77,7 +78,7 @@ func (_c *MockResourceRepo_GetCodeStyle_Call) Return(_a0 []Rule, _a1 error) *Moc
 	return _c
 }
 
-func (_c *MockResourceRepo_GetCodeStyle_Call) RunAndReturn(run func(context.Context, []string) ([]Rule, error)) *MockResourceRepo_GetCodeStyle_Call {
+func (_c *MockResourceRepo_GetCodeStyle_Call) RunAndReturn(run func(context.Context, []string, []string) ([]Rule, error)) *MockResourceRepo_GetCodeStyle_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/core/svc.go
+++ b/pkg/core/svc.go
@@ -14,8 +14,10 @@ import (
 // ResourceRepo defines the interface for managing code generation rules and resources.
 // It provides methods to retrieve rules by categories and language.
 type ResourceRepo interface {
-	// GetCodeStyle returns all rules that match the specified categories
-	GetCodeStyle(ctx context.Context, categories []string) ([]Rule, error)
+	// GetCodeStyle returns all rules that match the specified categories and keywords
+	// If keywords is empty, all rules matching categories are returned
+	// If a rule has no keywords defined, it is considered a general rule and is always returned
+	GetCodeStyle(ctx context.Context, categories []string, keywords []string) ([]Rule, error)
 }
 
 // Rule defines a universal structure for all types of code generation rules.
@@ -80,7 +82,8 @@ func New(resource ResourceRepo) *Service {
 // It returns a slice of rules and any error encountered during the retrieval.
 // Returns error if the repository access fails.
 func (s *Service) GetCodeStyle(ctx context.Context, categories []string) ([]Rule, error) {
-	return s.resource.GetCodeStyle(ctx, categories)
+	var keywords []string
+	return s.resource.GetCodeStyle(ctx, categories, keywords)
 }
 
 // String implements the Stringer interface for Rule.

--- a/pkg/core/svc_test.go
+++ b/pkg/core/svc_test.go
@@ -99,8 +99,11 @@ func TestService_GetCodeStyle(t *testing.T) {
 	}
 
 	mockRepo := NewMockResourceRepo(t)
+
+	var keywords []string
+
 	mockRepo.EXPECT().
-		GetCodeStyle(ctx, categories).
+		GetCodeStyle(ctx, categories, keywords).
 		Return(expectedRules, nil)
 
 	svc := New(mockRepo)

--- a/pkg/repo/static/repo.go
+++ b/pkg/repo/static/repo.go
@@ -22,14 +22,16 @@ type Rule struct {
 	Category    string    `mapstructure:"category"` // One of: "documentation", "testing", "code"
 	Description string    `mapstructure:"description"`
 	Examples    []Example `mapstructure:"examples"`
+	Keywords    []string  `mapstructure:"keywords,omitempty"`
 }
 
 // Example provides a usage example for a rule.
-// It includes a description of what the example demonstrates
-// and the actual code snippet.
+// It includes a description of what the example demonstrates,
+// the actual code snippet, and optional keywords for categorization.
 type Example struct {
-	Description string `mapstructure:"description"`
-	Code        string `mapstructure:"code"`
+	Description string   `mapstructure:"description"`
+	Code        string   `mapstructure:"code"`
+	Keywords    []string `mapstructure:"keywords,omitempty"`
 }
 
 // Repository provides functionality to work with static resources and code rules.

--- a/pkg/repo/static/repo.go
+++ b/pkg/repo/static/repo.go
@@ -7,6 +7,7 @@ package static
 
 import (
 	"context"
+	"strings"
 
 	"github.com/ksysoev/mcp-go-tools/pkg/core"
 )
@@ -53,7 +54,7 @@ func New(cfg *Config) *Repository {
 // convertRule converts internal Rule to core.Rule.
 // This is an internal helper method that maps between the configuration
 // and domain representations of a rule.
-func (r *Repository) convertRule(rule Rule) core.Rule {
+func (r *Repository) convertRule(rule *Rule) core.Rule {
 	return core.Rule{
 		Name:        rule.Name,
 		Category:    rule.Category,
@@ -81,7 +82,10 @@ func convertExamples(examples []Example) []core.Example {
 // GetCodeStyle returns all rules that match the specified categories.
 // It filters the configuration rules by categories, converting matches to core.Rule format.
 // Returns error if the context is cancelled.
-func (r *Repository) GetCodeStyle(ctx context.Context, categories []string) ([]core.Rule, error) {
+// GetCodeStyle returns rules filtered by categories and keywords.
+// If keywords is empty, all rules matching categories are returned.
+// If a rule has no keywords defined, it is considered a general rule and is always returned.
+func (r *Repository) GetCodeStyle(ctx context.Context, categories, keywords []string) ([]core.Rule, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -95,10 +99,27 @@ func (r *Repository) GetCodeStyle(ctx context.Context, categories []string) ([]c
 		}
 
 		for _, rule := range *r.config {
-			// Check if rule matches requested category
-			if categoryMap[rule.Category] {
-				rules = append(rules, r.convertRule(rule))
+			// Skip if category doesn't match
+			if len(categories) > 0 && !categoryMap[rule.Category] {
+				continue
 			}
+
+			// If no keywords specified or rule has no keywords, include the rule
+			if len(keywords) == 0 || len(rule.Keywords) == 0 {
+				rules = append(rules, r.convertRule(&rule))
+				continue
+			}
+
+			// Check if any of the requested keywords match rule's keywords
+			for _, keyword := range keywords {
+				for _, ruleKeyword := range rule.Keywords {
+					if strings.EqualFold(keyword, ruleKeyword) {
+						rules = append(rules, r.convertRule(&rule))
+						goto nextRule
+					}
+				}
+			}
+		nextRule:
 		}
 
 		return rules, nil

--- a/pkg/repo/static/repo_test.go
+++ b/pkg/repo/static/repo_test.go
@@ -13,6 +13,7 @@ func TestGetCodeStyle(t *testing.T) {
 			Name:        "test_rule1",
 			Category:    "testing",
 			Description: "Test rule 1",
+			Keywords:    []string{"unit", "basic"},
 			Examples: []Example{
 				{
 					Description: "Example 1",
@@ -24,6 +25,7 @@ func TestGetCodeStyle(t *testing.T) {
 			Name:        "test_rule2",
 			Category:    "testing",
 			Description: "Test rule 2",
+			Keywords:    []string{"integration", "advanced"},
 			Examples: []Example{
 				{
 					Description: "Example 2",
@@ -51,29 +53,63 @@ func TestGetCodeStyle(t *testing.T) {
 	tests := []struct {
 		name       string
 		categories []string
+		keywords   []string
 		want       int
 	}{
 		{
 			name:       "single category rules",
 			categories: []string{"testing"},
+			keywords:   nil,
 			want:       2,
 		},
 		{
 			name:       "multiple categories rules",
 			categories: []string{"testing", "code"},
+			keywords:   nil,
 			want:       3,
 		},
 		{
 			name:       "no matching rules",
 			categories: []string{"nonexistent"},
+			keywords:   nil,
 			want:       0,
+		},
+		{
+			name:       "filter by keyword unit",
+			categories: []string{"testing"},
+			keywords:   []string{"unit"},
+			want:       1,
+		},
+		{
+			name:       "filter by keyword advanced",
+			categories: []string{"testing"},
+			keywords:   []string{"advanced"},
+			want:       1,
+		},
+		{
+			name:       "filter by multiple keywords",
+			categories: []string{"testing"},
+			keywords:   []string{"unit", "integration"},
+			want:       2,
+		},
+		{
+			name:       "no keyword match",
+			categories: []string{"testing"},
+			keywords:   []string{"nonexistent"},
+			want:       0,
+		},
+		{
+			name:       "general rule without keywords",
+			categories: []string{"code"},
+			keywords:   []string{"any"},
+			want:       1,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var rules []core.Rule
-			rules, err := svc.GetCodeStyle(ctx, tt.categories)
+			rules, err := svc.GetCodeStyle(ctx, tt.categories, tt.keywords)
 
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)


### PR DESCRIPTION
Introduce an optional keywords field in Rule and Example structs for improved categorization. Enhance the GetCodeStyle method to support filtering by keywords in addition to categories.